### PR TITLE
fixed executions summary

### DIFF
--- a/cmd/kubectl-kubtest/commands/scripts/listrenderer.go
+++ b/cmd/kubectl-kubtest/commands/scripts/listrenderer.go
@@ -11,13 +11,13 @@ import (
 )
 
 type ListRenderer interface {
-	Render(list kubtest.ExecutionsSummary, writer io.Writer) error
+	Render(list kubtest.ExecutionsResult, writer io.Writer) error
 }
 
 type JSONListRenderer struct {
 }
 
-func (r JSONListRenderer) Render(list kubtest.ExecutionsSummary, writer io.Writer) error {
+func (r JSONListRenderer) Render(list kubtest.ExecutionsResult, writer io.Writer) error {
 	return json.NewEncoder(writer).Encode(list)
 }
 
@@ -25,13 +25,13 @@ type GoTemplateListRenderer struct {
 	Template string
 }
 
-func (r GoTemplateListRenderer) Render(list kubtest.ExecutionsSummary, writer io.Writer) error {
+func (r GoTemplateListRenderer) Render(list kubtest.ExecutionsResult, writer io.Writer) error {
 	tmpl, err := template.New("result").Parse(r.Template)
 	if err != nil {
 		return err
 	}
 
-	for _, execution := range list {
+	for _, execution := range list.Results {
 		err := tmpl.Execute(writer, execution)
 		if err != nil {
 			return err
@@ -45,7 +45,7 @@ func (r GoTemplateListRenderer) Render(list kubtest.ExecutionsSummary, writer io
 type RawListRenderer struct {
 }
 
-func (r RawListRenderer) Render(list kubtest.ExecutionsSummary, writer io.Writer) error {
+func (r RawListRenderer) Render(list kubtest.ExecutionsResult, writer io.Writer) error {
 	ui.Table(list, writer)
 	return nil
 }

--- a/pkg/api/v1/client/direct.go
+++ b/pkg/api/v1/client/direct.go
@@ -74,7 +74,7 @@ func (c DirectScriptsAPI) GetExecution(scriptID, executionID string) (execution 
 }
 
 // ListExecutions list all executions for given script name
-func (c DirectScriptsAPI) ListExecutions(scriptID string) (executions kubtest.ExecutionsSummary, err error) {
+func (c DirectScriptsAPI) ListExecutions(scriptID string) (executions kubtest.ExecutionsResult, err error) {
 	uri := c.getURI("/scripts/%s/executions", scriptID)
 	resp, err := c.client.Get(uri)
 	if err != nil {
@@ -179,7 +179,7 @@ func (c DirectScriptsAPI) getExecutionFromResponse(resp *http.Response) (executi
 	return
 }
 
-func (c DirectScriptsAPI) getExecutionsFromResponse(resp *http.Response) (executions kubtest.ExecutionsSummary, err error) {
+func (c DirectScriptsAPI) getExecutionsFromResponse(resp *http.Response) (executions kubtest.ExecutionsResult, err error) {
 	defer resp.Body.Close()
 
 	err = json.NewDecoder(resp.Body).Decode(&executions)

--- a/pkg/api/v1/client/interface.go
+++ b/pkg/api/v1/client/interface.go
@@ -15,7 +15,7 @@ type HTTPClient interface {
 type Client interface {
 	GetScript(id string) (script kubtest.Script, err error)
 	GetExecution(scriptID, executionID string) (execution kubtest.Execution, err error)
-	ListExecutions(scriptID string) (executions kubtest.ExecutionsSummary, err error)
+	ListExecutions(scriptID string) (executions kubtest.ExecutionsResult, err error)
 	AbortExecution(script string, id string) error
 	CreateScript(options CreateScriptOptions) (script kubtest.Script, err error)
 	ExecuteScript(id, namespace, executionName string, executionParams map[string]string) (execution kubtest.Execution, err error)

--- a/pkg/api/v1/client/proxy.go
+++ b/pkg/api/v1/client/proxy.go
@@ -84,7 +84,7 @@ func (c ProxyScriptsAPI) GetExecution(scriptID, executionID string) (execution k
 }
 
 // ListExecutions list all executions for given script name
-func (c ProxyScriptsAPI) ListExecutions(scriptID string) (executions kubtest.ExecutionsSummary, err error) {
+func (c ProxyScriptsAPI) ListExecutions(scriptID string) (executions kubtest.ExecutionsResult, err error) {
 	uri := c.getURI("/scripts/%s/executions", scriptID)
 	req := c.GetProxy("GET").Suffix(uri)
 	resp := req.Do(context.Background())
@@ -184,7 +184,7 @@ func (c ProxyScriptsAPI) getExecutionFromResponse(resp rest.Result) (execution k
 	return execution, err
 }
 
-func (c ProxyScriptsAPI) getExecutionsFromResponse(resp rest.Result) (executions kubtest.ExecutionsSummary, err error) {
+func (c ProxyScriptsAPI) getExecutionsFromResponse(resp rest.Result) (executions kubtest.ExecutionsResult, err error) {
 	bytes, err := resp.Raw()
 	if err != nil {
 		return executions, err

--- a/pkg/api/v1/kubtest/model_executions_result_extended.go
+++ b/pkg/api/v1/kubtest/model_executions_result_extended.go
@@ -1,11 +1,9 @@
 package kubtest
 
-type ExecutionsSummary []ExecutionSummary
-
-func (executions ExecutionsSummary) Table() (header []string, output [][]string) {
+func (result ExecutionsResult) Table() (header []string, output [][]string) {
 	header = []string{"Script", "Type", "Name", "ID", "Status"}
 
-	for _, e := range executions {
+	for _, e := range result.Results {
 		var status string
 		if e.Status != nil {
 			status = string(*e.Status)


### PR DESCRIPTION
## Pull request description 

Fix after last refactor kubectl plugin was using invalid (old) data structures - API was updated 

## Checklist (choose whats happened)

- [x] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-